### PR TITLE
nar: set content type and name

### DIFF
--- a/misc.js
+++ b/misc.js
@@ -64,6 +64,16 @@ function narinfoVisitFields(narinfo, handler) {
   }
 }
 
+const PATH_PATTERN = /\/([0-9a-z]{32})-([^/]+)/;
+
+function pathHash(path) {
+  return PATH_PATTERN.exec(path)[1];
+}
+
+function pathName(path) {
+  return PATH_PATTERN.exec(path)[2];
+}
+
 function narReadInt(reader) {
   const i = reader.data.getBigInt64(reader.pos, true);
   reader.pos += 8;

--- a/nar.html
+++ b/nar.html
@@ -11,7 +11,7 @@
       const nar = await cacheGetNar(cacheBase, narinfo);
       console.log(nar); // %%%
 
-      const renderNode = (node) => {
+      const renderNode = (name, node) => {
         let vNode;
         switch (node.type) {
           case 'regular':
@@ -58,7 +58,7 @@
                 vDt.textContent = entry.name;
                 vEntries.appendChild(vDt);
                 const vDd = document.createElement('dd');
-                vDd.appendChild(renderNode(entry.node));
+                vDd.appendChild(renderNode(entry.name, entry.node));
                 vEntries.appendChild(vDd);
               }
               vNode.appendChild(vEntries);
@@ -72,7 +72,16 @@
         }
         return vNode;
       };
-      document.getElementById('root').appendChild(renderNode(nar.root));
+      let rootPath;
+      narinfoVisitFields(narinfo, (k, v) => {
+        switch (k) {
+          case 'StorePath':
+            rootPath = v;
+            break;
+        }
+      });
+      const rootName = pathName(rootPath);
+      document.getElementById('root').appendChild(renderNode(rootName, nar.root));
     } catch (e) {
       console.error(e);
     }

--- a/nar.html
+++ b/nar.html
@@ -27,14 +27,18 @@
             vPrepare.value = 'create object url';
             vPrepare.onclick = (e) => {
               vPrepare.disabled = true;
-              const url = URL.createObjectURL(new Blob([node.contents]));
-              vNode.appendChild(document.createTextNode(' '));
-              const vLink = document.createElement('a');
-              vLink.href = url;
-              vLink.textContent = 'contents';
-              vNode.appendChild(vLink);
+              const blob = new Blob([node.contents], {type: 'application/octet-stream'});
+              const url = URL.createObjectURL(blob);
+              vBlob.href = url;
+              vBlob.hidden = false;
             };
             vNode.appendChild(vPrepare);
+            vNode.appendChild(document.createTextNode(' '));
+            const vBlob = document.createElement('a');
+            vBlob.download = name;
+            vBlob.hidden = true;
+            vBlob.textContent = 'contents';
+            vNode.appendChild(vBlob);
             break;
           case 'symlink':
             vNode = document.createElement('p');


### PR DESCRIPTION
fixes #1

Some nearby changes as well: setting the download name. This required adding a `name` parameter to `renderNode`, which will help with #3. To set the root node's name, there's a new `pathName` helper in misc.