### PR TITLE
drv: linkify more stuff

### DIFF
--- a/drv.html
+++ b/drv.html
@@ -2,10 +2,34 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>drv view</title>
-<dl>
+<style>
+  body {
+    margin: 1.5rem;
+    font-family: sans-serif;
+  }
+  .drv > dt {
+    margin-top: 0.5rem;
+  }
+  .drv table {
+    margin: 0rem -1rem;
+    border-spacing: 1rem 0rem;
+  }
+  .drv thead td {
+    border-bottom: 1px solid #d0d0d0;
+    vertical-align: bottom;
+  }
+  .drv td {
+    vertical-align: baseline;
+  }
+  .verbatim {
+    font-family: monospace;
+    white-space: pre-wrap;
+  }
+</style>
+<dl class="drv">
   <dt>Outputs</dt>
   <dd>
-    <table id="outputs" border="1">
+    <table id="outputs">
       <thead>
         <tr>
           <td>Name</td>
@@ -18,7 +42,7 @@
   </dd>
   <dt>Input derivations</dt>
   <dd>
-    <table id="input_drvs" border="1">
+    <table id="input_drvs">
       <thead>
         <tr>
           <td>Path</td>
@@ -37,7 +61,7 @@
   <dd><ol id="builder_args"></ol></dd>
   <dt>Builder environment</dt>
   <dd>
-    <table id="env" border="1">
+    <table id="env">
       <thead>
         <tr>
           <td>Name</td>
@@ -67,8 +91,9 @@
 
       const [outputs, inputDrvs, inputSrcs, platform, builder, builderArgs, env] = drv;
       const vOutputs = document.getElementById('outputs');
+      const vOutputsBody = vOutputs.createTBody();
       for (const [name, path, narHashAlgorithm, narHash] of outputs) {
-        const row = vOutputs.insertRow(-1);
+        const row = vOutputsBody.insertRow(-1);
         row.insertCell(-1).textContent = name;
         const pathCell = row.insertCell(-1);
         const pathLink = document.createElement('a');
@@ -80,8 +105,9 @@
         row.insertCell(-1).textContent = narHash;
       }
       const vInputDrvs = document.getElementById('input_drvs');
+      const vInputDrvsBody = vInputDrvs.createTBody();
       for (const [drvPath, drvOutputs] of inputDrvs) {
-        const row = vInputDrvs.insertRow(-1);
+        const row = vInputDrvsBody.insertRow(-1);
         const drvCell = row.insertCell(-1);
         const drvLink = document.createElement('a');
         const drvHash = pathHash(drvPath);
@@ -130,14 +156,24 @@
       const vBuilderArgs = document.getElementById('builder_args');
       for (const builderArg of builderArgs) {
         const item = document.createElement('li');
-        item.appendChild(linkify(builderArg));
+        const vBuilderArg = document.createElement('span');
+        vBuilderArg.className = 'verbatim';
+        vBuilderArg.appendChild(linkify(builderArg));
+        item.appendChild(vBuilderArg);
         vBuilderArgs.appendChild(item);
       }
       const vEnv = document.getElementById('env');
+      const vEnvBody = vEnv.createTBody();
       for (const [name, value] of env) {
-        const row = vEnv.insertRow(-1);
-        row.insertCell(-1).textContent = name;
-        row.insertCell(-1).appendChild(linkify(value));
+        const row = vEnvBody.insertRow(-1);
+        const vName = document.createElement('span');
+        vName.className = 'verbatim';
+        vName.textContent = name;
+        row.insertCell(-1).appendChild(vName);
+        const vValue = document.createElement('span');
+        vValue.className = 'verbatim';
+        vValue.appendChild(linkify(value))
+        row.insertCell(-1).appendChild(vValue);
       }
     } catch (e) {
       console.error(e);

--- a/drv.html
+++ b/drv.html
@@ -1,4 +1,7 @@
 <!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>drv view</title>
 <dl>
   <dt>Outputs</dt>
   <dd>
@@ -51,7 +54,13 @@
       const options = new URL(window.location).searchParams;
       const cacheBase = options.get('cache_base');
       const hash = options.get('hash');
+
       const drvNarinfo = await cacheGetNarinfo(cacheBase, hash);
+
+      const rootPath = narinfoPath(drvNarinfo);
+      const rootName = pathName(rootPath);
+      document.title = rootName;
+
       const drvNar = await cacheGetNar(cacheBase, drvNarinfo);
       const drv = drvParse(new TextDecoder().decode(drvNar.root.contents));
 

--- a/drv.html
+++ b/drv.html
@@ -83,7 +83,11 @@
       }
       const vInputSrcs = document.getElementById('input_srcs');
       for (const inputSrc of inputSrcs) {
-        vInputSrcs.insertRow(-1).insertCell(-1).textContent = inputSrc;
+        const inputSrcLink = document.createElement('a');
+        const inputSrcHash = pathHash(inputSrc);
+        inputSrcLink.href = `nar.html?cache_base=${encodeURIComponent(cacheBase)}&hash=${encodeURIComponent(inputSrcHash)}`;
+        inputSrcLink.textContent = inputSrc;
+        vInputSrcs.insertRow(-1).insertCell(-1).appendChild(inputSrcLink);
       }
       document.getElementById('platform').textContent = platform;
       document.getElementById('builder').textContent = builder;

--- a/drv.html
+++ b/drv.html
@@ -1,49 +1,49 @@
 <!doctype html>
-<table id="outputs" border="1">
-  <thead>
-    <tr>
-      <td>Output name</td>
-      <td>Path</td>
-      <td>Hash algorithm</td>
-      <td>Hash</td>
-    </tr>
-  </thead>
-</table>
-<table id="input_drvs" border="1">
-  <thead>
-    <tr>
-      <td>Input derivation</td>
-      <td>Outputs</td>
-    </tr>
-  </thead>
-</table>
-<table id="input_srcs" border="1">
-  <thead>
-    <tr>
-      <td>Input source</td>
-    </tr>
-  </thead>
-</table>
 <dl>
+  <dt>Outputs</dt>
+  <dd>
+    <table id="outputs" border="1">
+      <thead>
+        <tr>
+          <td>Name</td>
+          <td>Path</td>
+          <td>Hash algorithm</td>
+          <td>Hash</td>
+        </tr>
+      </thead>
+    </table>
+  </dd>
+  <dt>Input derivations</dt>
+  <dd>
+    <table id="input_drvs" border="1">
+      <thead>
+        <tr>
+          <td>Path</td>
+          <td>Outputs</td>
+        </tr>
+      </thead>
+    </table>
+  </dd>
+  <dt>Input sources</dt>
+  <dd><ul id="input_srcs"></ul></dd>
   <dt>Platform</dt>
   <dd id="platform"></dd>
-</dl>
-<dl>
   <dt>Builder</dt>
   <dd id="builder"></dd>
-</dl>
-<dl>
   <dt>Builder arguments</dt>
   <dd><ol id="builder_args"></ol></dd>
+  <dt>Builder environment</dt>
+  <dd>
+    <table id="env" border="1">
+      <thead>
+        <tr>
+          <td>Name</td>
+          <td>Value</td>
+        </tr>
+      </thead>
+    </table>
+  </dd>
 </dl>
-<table id="env" border="1">
-  <thead>
-    <tr>
-      <td>Environment variable</td>
-      <td>Value</td>
-    </tr>
-  </thead>
-</table>
 <script src="misc.js"></script>
 <script>
   (async () => {
@@ -83,11 +83,13 @@
       }
       const vInputSrcs = document.getElementById('input_srcs');
       for (const inputSrc of inputSrcs) {
+        const item = document.createElement('li');
         const inputSrcLink = document.createElement('a');
         const inputSrcHash = pathHash(inputSrc);
         inputSrcLink.href = `nar.html?cache_base=${encodeURIComponent(cacheBase)}&hash=${encodeURIComponent(inputSrcHash)}`;
         inputSrcLink.textContent = inputSrc;
-        vInputSrcs.insertRow(-1).insertCell(-1).appendChild(inputSrcLink);
+        item.appendChild(inputSrcLink);
+        vInputSrcs.appendChild(item);
       }
       document.getElementById('platform').textContent = platform;
       document.getElementById('builder').textContent = builder;

--- a/drv.html
+++ b/drv.html
@@ -53,6 +53,7 @@
     try {
       const options = new URL(window.location).searchParams;
       const cacheBase = options.get('cache_base');
+      const cacheBaseBin = 'https://cdn.glitch.me/35f4f809-f949-484d-af9c-269b3b7abc78/'; // %%%
       const hash = options.get('hash');
 
       const drvNarinfo = await cacheGetNarinfo(cacheBase, hash);
@@ -71,8 +72,7 @@
         row.insertCell(-1).textContent = name;
         const pathCell = row.insertCell(-1);
         const pathLink = document.createElement('a');
-        const cacheBaseBin = 'https://cdn.glitch.me/35f4f809-f949-484d-af9c-269b3b7abc78/'; // %%%
-        const outputHash = /([0-9a-z]+)-[^/]+/.exec(path)[1];
+        const outputHash = pathHash(path);
         pathLink.href = `nar.html?cache_base=${encodeURIComponent(cacheBaseBin)}&hash=${encodeURIComponent(outputHash)}`;
         pathLink.textContent = path;
         pathCell.appendChild(pathLink);
@@ -84,35 +84,60 @@
         const row = vInputDrvs.insertRow(-1);
         const drvCell = row.insertCell(-1);
         const drvLink = document.createElement('a');
-        const drvHash = /([0-9a-z]+)-[^/]+/.exec(drvPath)[1];
+        const drvHash = pathHash(drvPath);
         drvLink.href = `?cache_base=${encodeURIComponent(cacheBase)}&hash=${encodeURIComponent(drvHash)}`;
         drvLink.textContent = drvPath;
         drvCell.appendChild(drvLink);
         row.insertCell(-1).textContent = drvOutputs.join(', ');
       }
+      const inputSrcHashes = {};
       const vInputSrcs = document.getElementById('input_srcs');
       for (const inputSrc of inputSrcs) {
         const item = document.createElement('li');
         const inputSrcLink = document.createElement('a');
         const inputSrcHash = pathHash(inputSrc);
+        inputSrcHashes[inputSrcHash] = true;
         inputSrcLink.href = `nar.html?cache_base=${encodeURIComponent(cacheBase)}&hash=${encodeURIComponent(inputSrcHash)}`;
         inputSrcLink.textContent = inputSrc;
         item.appendChild(inputSrcLink);
         vInputSrcs.appendChild(item);
       }
       document.getElementById('platform').textContent = platform;
-      document.getElementById('builder').textContent = builder;
+      const maybeLinkifySingle = (path) => {
+        const parts = pathMatch(path);
+        if (!parts) return null;
+        const link = document.createElement('a');
+        const hash = parts[1];
+        const isInputSrc = hash in inputSrcHashes;
+        const base = isInputSrc ? cacheBase : cacheBaseBin;
+        link.href = `nar.html?cache_base=${encodeURIComponent(base)}&hash=${encodeURIComponent(hash)}`;
+        link.textContent = path;
+        return link;
+      };
+      const linkifySingle = (path) => {
+        return maybeLinkifySingle(path) || document.createTextNode(path)
+      };
+      const linkify = (text) => {
+        // Nix allows '=' too, but that works less well
+        // https://github.com/NixOS/nix/blob/2.8.1/src/libstore/path.cc#L14-L17
+        return uiNodify(text, /[\/\w+?.-]+/g, (m) => {
+          const path = m[0];
+          if (!path.startsWith('/')) return null;
+          return maybeLinkifySingle(path);
+        });
+      };
+      document.getElementById('builder').appendChild(linkifySingle(builder));
       const vBuilderArgs = document.getElementById('builder_args');
       for (const builderArg of builderArgs) {
         const item = document.createElement('li');
-        item.textContent = builderArg;
+        item.appendChild(linkify(builderArg));
         vBuilderArgs.appendChild(item);
       }
       const vEnv = document.getElementById('env');
       for (const [name, value] of env) {
         const row = vEnv.insertRow(-1);
         row.insertCell(-1).textContent = name;
-        row.insertCell(-1).textContent = value;
+        row.insertCell(-1).appendChild(linkify(value));
       }
     } catch (e) {
       console.error(e);

--- a/misc.js
+++ b/misc.js
@@ -276,3 +276,23 @@ function dbReferrers(db) {
   }
   return referrers;
 }
+
+function uiNodify(text, pattern, replacer) {
+  const frag = document.createDocumentFragment();
+  let lastEnd = 0;
+  while (true) {
+    const m = pattern.exec(text);
+    if (!m) break;
+    const node = replacer(m, text);
+    if (!node) continue;
+    if (lastEnd < m.index) {
+      frag.appendChild(document.createTextNode(text.slice(lastEnd, m.index)));
+    }
+    frag.appendChild(node);
+    lastEnd = pattern.lastIndex;
+  }
+  if (lastEnd < text.length) {
+    frag.appendChild(document.createTextNode(text.slice(lastEnd)));
+  }
+  return frag;
+}

--- a/misc.js
+++ b/misc.js
@@ -64,6 +64,18 @@ function narinfoVisitFields(narinfo, handler) {
   }
 }
 
+function narinfoPath(narinfo) {
+  let rootPath;
+  narinfoVisitFields(narinfo, (k, v) => {
+    switch (k) {
+      case 'StorePath':
+        rootPath = v;
+        break;
+    }
+  });
+  return rootPath;
+}
+
 const PATH_PATTERN = /\/([0-9a-z]{32})-([^/]+)/;
 
 function pathHash(path) {

--- a/misc.js
+++ b/misc.js
@@ -76,14 +76,18 @@ function narinfoPath(narinfo) {
   return rootPath;
 }
 
-const PATH_PATTERN = /\/([0-9a-z]{32})-([^/]+)/;
+const PATH_PATTERN = /\/([0-9a-z]{32})-([^/]+)(.*)/;
+
+function pathMatch(path) {
+  return PATH_PATTERN.exec(path);
+}
 
 function pathHash(path) {
-  return PATH_PATTERN.exec(path)[1];
+  return pathMatch(path)[1];
 }
 
 function pathName(path) {
-  return PATH_PATTERN.exec(path)[2];
+  return pathMatch(path)[2];
 }
 
 function narReadInt(reader) {

--- a/nar.html
+++ b/nar.html
@@ -16,6 +16,7 @@
   }
   .name {
     font-family: monospace;
+    white-space: pre;
   }
   .attr {
     display: inline-block;
@@ -34,7 +35,8 @@
   }
   .target {
     font-family: monospace;
-    color: #808080
+    color: #808080;
+    white-space: pre;
   }
 </style>
 <div id="root"></div>

--- a/nar.html
+++ b/nar.html
@@ -45,7 +45,13 @@
       const options = new URL(window.location).searchParams;
       const cacheBase = options.get('cache_base');
       const hash = options.get('hash');
+
       const narinfo = await cacheGetNarinfo(cacheBase, hash);
+
+      const rootPath = narinfoPath(narinfo);
+      const rootName = pathName(rootPath);
+      document.title = rootName;
+
       const nar = await cacheGetNar(cacheBase, narinfo);
       console.log(nar); // %%%
 
@@ -135,16 +141,6 @@
         }
         return vNode;
       };
-      let rootPath;
-      narinfoVisitFields(narinfo, (k, v) => {
-        switch (k) {
-          case 'StorePath':
-            rootPath = v;
-            break;
-        }
-      });
-      const rootName = pathName(rootPath);
-      document.title = rootName;
       document.getElementById('root').appendChild(renderNode(rootName, nar.root));
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
fixes #4

in more places, find store paths heuristically and link them

mostly find path-looking substrings and check for (1) absolute path and (2) contains hash-looking thing

things known to be in the input srcs go to the same cache base. we don't know the hashes of the input derivation outputs, so assume everything else is an output

also some ui adjustment