### PR TITLE
drv: un-hardcode cacheBaseBin

### DIFF
--- a/drv.html
+++ b/drv.html
@@ -77,7 +77,7 @@
     try {
       const options = new URL(window.location).searchParams;
       const cacheBase = options.get('cache_base');
-      const cacheBaseBin = 'https://cdn.glitch.me/35f4f809-f949-484d-af9c-269b3b7abc78/'; // %%%
+      const cacheBaseBin = options.get('cache_base_bin') || cacheBase;
       const hash = options.get('hash');
 
       const drvNarinfo = await cacheGetNarinfo(cacheBase, hash);

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <form name="drv" action="drv.html">
   <p><label>cache base<br><input name="cache_base" value="https://tmpnix-gsdrv.glitch.me/drvs/"></label></p>
   <p><label>hash<br><input name="hash" value="52xwnqlqa6l4bbf01yifahb517zax89d"></label></p>
+  <p><label>cache base bin<br><input name="cache_base_bin" value="https://cdn.glitch.me/35f4f809-f949-484d-af9c-269b3b7abc78/"></label></p>
   <p><input type="submit" value="view drv"></p>
 </form>
 <form name="nar" action="nar.html">


### PR DESCRIPTION
fixes #5

now to be set in `&cache_base_bin=...` in the url params